### PR TITLE
Attempt to make SpriteMask on child GameObjects work during PNG render

### DIFF
--- a/Assets/Shapes2D/Editor/ShapeEditor.cs
+++ b/Assets/Shapes2D/Editor/ShapeEditor.cs
@@ -222,7 +222,7 @@
                 if (canvas) {
                     backup.Add((s.gameObject.layer, s.GetComponent<Graphic>().enabled));
                     s.gameObject.layer = 31;
-                    s.GetComponent<Graphic>().enabled = true;
+                    s.GetComponent<Graphic>().enabled = false;
                 } else  {
                     backup.Add((s.gameObject.layer, s.gameObject.GetComponent<SpriteRenderer>().enabled));
                     s.gameObject.layer = 31;

--- a/Assets/Shapes2D/Editor/ShapeEditor.cs
+++ b/Assets/Shapes2D/Editor/ShapeEditor.cs
@@ -213,6 +213,23 @@
             RenderTexture oldRT = RenderTexture.active;
             RenderTexture.active = rt;
 
+            // create a backup of the shape's layer and enabled state so we can manipulate 
+            // them and restore later.  set all shapes to layer 31 and disable their 
+            // graphics component.  this leaves any other components enabled so e.g. 
+            // SpriteMask on a child will still affect a parent.
+            List<(int oldLayer, bool wasEnabled)> backup = new List<(int oldLayer, bool wasEnabled)>();
+            foreach (Shape s in shapes) {
+                if (canvas) {
+                    backup.Add((s.gameObject.layer, s.GetComponent<Graphic>().enabled));
+                    s.gameObject.layer = 31;
+                    s.GetComponent<Graphic>().enabled = true;
+                } else  {
+                    backup.Add((s.gameObject.layer, s.gameObject.GetComponent<SpriteRenderer>().enabled));
+                    s.gameObject.layer = 31;
+                    s.gameObject.GetComponent<SpriteRenderer>().enabled = false;
+                }
+            }
+
             // draw each shape with blending turned off, and layer them on top of each
             // other with blending between shapes but not between a shape and the 
             // camera's background color, which is what would happen if we just let the
@@ -224,7 +241,16 @@
             // shapes but not between a shape and the background color, so that's why
             // we have to do it manually.
             Texture2D dstTex = null;
-            foreach (Shape s in shapes) {
+            for (int i = 0; i < shapes.Count; i++) {
+                if (!backup[i].wasEnabled) 
+                    continue;
+                // set this shape's graphic's enabled state to true so it will render
+                var s = shapes[i];
+                if (canvas) {
+                    s.GetComponent<Graphic>().enabled = true;
+                } else {
+                    s.gameObject.GetComponent<SpriteRenderer>().enabled = true;
+                }
                 if (canvas) {
                     Graphic g = s.GetComponent<Graphic>(); 
                     g.enabled = true;
@@ -248,6 +274,23 @@
                     } else {
                         s.GetComponent<Mask>().showMaskGraphic = false;
                     }
+                }
+                // set the graphic's enabled back to false
+                if (canvas) {
+                    s.GetComponent<Graphic>().enabled = false;
+                } else {
+                    s.gameObject.GetComponent<SpriteRenderer>().enabled = false;
+                }
+            }
+
+            // restore the layers and graphic enabled states
+            for (int i = 0; i < shapes.Count; i++) {
+                var s = shapes[i];
+                s.gameObject.layer = backup[i].oldLayer;
+                if (canvas) {
+                    s.GetComponent<Graphic>().enabled = backup[i].wasEnabled;
+                } else {
+                    s.gameObject.GetComponent<SpriteRenderer>().enabled = backup[i].wasEnabled;
                 }
             }
             


### PR DESCRIPTION
This is a very quick update to try and get SpriteMask to work during convert to sprite, if it's on a child GameObject.  During convert to sprite, shapes are rendered one at a time, and prior to this only the shape currently being rendered was on a layer visible to the camera, so anything else in the hierarchy would not affect the render.  This change makes it so the entire hierarchy is on the correct layer, but graphics components are disabled except for the shape being rendered.  Barely tested and not tested at all with UI.

Before merging this would need some cleanup to factor with DisableUIGraphics().  Also, if a SpriteMask component is on a child but the child doesn't have a Shape component, it won't affect the png.